### PR TITLE
Restore previous window in s:ColorClear

### DIFF
--- a/plugin/colorizer.vim
+++ b/plugin/colorizer.vim
@@ -321,9 +321,11 @@ function s:ColorClear() "{{{2
   augroup Colorizer
     au!
   augroup END
-  let savepos = tabpagenr()
+  let save_tab = tabpagenr()
+  let save_win = winnr()
   tabdo windo call s:ClearMatches()
-  exe 'tabn '.savepos
+  exe 'tabn '.save_tab
+  exe save_win . 'wincmd w'
 endfunction
 function s:ClearMatches() "{{{2
   if !exists('w:colormatches')


### PR DESCRIPTION
Currently only the previous tab gets restored, but `:windo` requires to
restore the window, too.
