### PR TITLE
toggle msg is noisy call s:ColorHighlight directly

### DIFF
--- a/plugin/colorizer.vim
+++ b/plugin/colorizer.vim
@@ -370,7 +370,7 @@ elseif g:colorizer_fgcontrast >= len(s:predefined_fgcolors['dark'])
 endif
 let s:saved_fgcontrast = g:colorizer_fgcontrast
 if !exists('g:colorizer_startup') || g:colorizer_startup
-  call s:ColorToggle()
+  call s:ColorHighlight(0)
 endif
 "Define commands {{{2
 command -bar -bang ColorHighlight call s:ColorHighlight(1, "<bang>")


### PR DESCRIPTION
原因：每次打开vim都会弹出 `Enabled color code highlighting.`，很烦人。
