### PR TITLE
Fix auto-startup regression

### DIFF
--- a/autoload/colorizer.vim
+++ b/autoload/colorizer.vim
@@ -370,9 +370,6 @@ elseif g:colorizer_fgcontrast >= len(s:predefined_fgcolors['dark'])
   let g:colorizer_fgcontrast = len(s:predefined_fgcolors['dark']) - 1
 endif
 let s:saved_fgcontrast = g:colorizer_fgcontrast
-if !exists('g:colorizer_startup') || g:colorizer_startup
-  call colorizer#ColorHighlight(0)
-endif
 
 " Restoration and modelines {{{1
 let &cpo = s:keepcpo

--- a/plugin/colorizer.vim
+++ b/plugin/colorizer.vim
@@ -53,6 +53,9 @@ nnoremap <silent> <Plug>Colorizer :ColorToggle<CR>
 if !hasmapto("<Plug>Colorizer") && (!exists("g:colorizer_nomap") || g:colorizer_nomap == 0)
   nmap <unique> <Leader>tc <Plug>Colorizer
 endif
+if !exists('g:colorizer_startup') || g:colorizer_startup
+  call colorizer#ColorHighlight(0)
+endif
 
 " Cleanup and modelines {{{1
 let &cpo = s:save_cpo


### PR DESCRIPTION
Moving the `if g:colorizer_startup` block from plugin/ to autoload/ broke the plugin being automatically started, therefore moved it back to plugin/.
