### PR TITLE
ignored 8 digit hex-values including alpha transparency values

### DIFF
--- a/autoload/colorizer.vim
+++ b/autoload/colorizer.vim
@@ -103,7 +103,7 @@ endfunction
 function! s:HexCode(str, lineno) "{{{2
   let ret = []
   let place = 0
-  let colorpat = '#[0-9A-Fa-f]\{3\}\>\|#[0-9A-Fa-f]\{6\}\>'
+  let colorpat = '#[0-9A-Fa-f]\{3\}\>\|#[0-9A-Fa-f]\{6\}\>\|#[0-9A-Fa-f]\{8\}\>'
   while 1
     let foundcolor = matchstr(a:str, colorpat, place)
     if foundcolor == ''
@@ -113,6 +113,8 @@ function! s:HexCode(str, lineno) "{{{2
     let pat = foundcolor . '\>'
     if len(foundcolor) == 4
       let foundcolor = substitute(foundcolor, '[[:xdigit:]]', '&&', 'g')
+    elseif len(foundcolor) == 9
+      let foundcolor = substitute(foundcolor, '#[0-9A-Fa-f]\{2}', '#', 'g')
     endif
     call add(ret, [foundcolor, pat])
   endwhile


### PR DESCRIPTION
Hi,

I've been using hex color values that include alpha channels in some of my config files. Unfortunately those haven't been recognized by your otherwise awesome plugin.

I added 8 digit hex values to the recognized color patterns and have the alpha channels (first two digits) of the hex value ignored.