### PR TITLE
Initial support for termguicolors

### DIFF
--- a/plugin/colorizer.vim
+++ b/plugin/colorizer.vim
@@ -45,7 +45,7 @@
 " different colors. GUI version is much quicker.
 
 " Reload guard and 'compatible' handling {{{1
-if exists("loaded_colorizer") || v:version < 700 || !(has("gui_running") || &t_Co == 256)
+if exists("loaded_colorizer") || v:version < 700 || !(has("gui_running") || &t_Co == 256 || &termguicolors)
   finish
 endif
 let loaded_colorizer = 1


### PR DESCRIPTION
termguicolors is a new option in vim 8 which allows vim to display 24 bit colours in ISO-8613-3 compatible terminals like xterm or [hterm](https://chromium.googlesource.com/apps/libapps/+/master/hterm/)

This commit starts to address https://github.com/lilydjwg/colorizer/issues/26